### PR TITLE
Made inbox page responsive

### DIFF
--- a/src/Modules/FileTracking/components/Inbox.jsx
+++ b/src/Modules/FileTracking/components/Inbox.jsx
@@ -11,34 +11,34 @@ import {
 
 export default function Inboxfunc() {
   const [files, setFiles] = useState([]);
+  const [selectedFile, setSelectedFile] = useState(null);
   const token = localStorage.getItem("authToken");
   const role = useSelector((state) => state.user.role);
   const username = useSelector((state) => state.user.name);
   let current_module = useSelector((state) => state.module.current_module);
   current_module = current_module.split(" ").join("").toLowerCase();
+
+  // Helper function to convert dates
   const convertDate = (date) => {
     const d = new Date(date);
     return d.toLocaleString();
   };
+
+  // Fetch files on component mount
   useEffect(() => {
     const getFiles = async () => {
       try {
-        const response = await axios.get(
-          `${getFilesRoute}`,
-
-          {
-            params: {
-              username,
-              designation: role,
-              src_module: current_module,
-            },
-            withCredentials: true,
-            headers: {
-              Authorization: `Token ${token}`,
-            },
+        const response = await axios.get(`${getFilesRoute}`, {
+          params: {
+            username,
+            designation: role,
+            src_module: current_module,
           },
-        );
-        // Set the response data to the files state
+          withCredentials: true,
+          headers: {
+            Authorization: `Token ${token}`,
+          },
+        });
         setFiles(response.data);
         console.log(response.data);
       } catch (err) {
@@ -46,239 +46,280 @@ export default function Inboxfunc() {
       }
     };
 
-    // Call the getFiles function to fetch data on component mount
     getFiles();
-  }, []);
+  }, [username, role, current_module, token]);
 
-  const [selectedFile, setSelectedFile] = useState(null);
-
+  // Archive file handler
   const handleArchive = async (fileID) => {
-    // eslint-disable-next-line no-unused-vars
-    const response = await axios.post(
-      `${createArchiveRoute}`,
-      {
-        file_id: fileID,
-      },
-      {
-        params: {
-          username,
-          designation: role,
-          src_module: current_module,
+    try {
+      await axios.post(
+        `${createArchiveRoute}`,
+        { file_id: fileID },
+        {
+          params: {
+            username,
+            designation: role,
+            src_module: current_module,
+          },
+          withCredentials: true,
+          headers: {
+            Authorization: `Token ${token}`,
+          },
         },
-        withCredentials: true,
-        headers: {
-          Authorization: `Token ${token}`,
-        },
-      },
-    );
-    const updatedFiles = files.filter((file) => file.id !== fileID);
-    setFiles(updatedFiles);
+      );
+      // Remove archived file from the list
+      const updatedFiles = files.filter((file) => file.id !== fileID);
+      setFiles(updatedFiles);
+    } catch (error) {
+      console.error("Error archiving file:", error);
+    }
   };
 
   const handleBack = () => {
     setSelectedFile(null);
   };
 
+  // Using e.currentTarget ensures the style is applied to the ActionIcon element
   const handleMouseEnter = (e) => {
-    e.target.style.backgroundColor = e.target.dataset.hoverColor; // Set hover color
+    e.currentTarget.style.backgroundColor = e.currentTarget.dataset.hoverColor;
   };
 
   const handleMouseLeave = (e) => {
-    e.target.style.backgroundColor = e.target.dataset.defaultColor; // Reset to default
+    e.currentTarget.style.backgroundColor =
+      e.currentTarget.dataset.defaultColor;
   };
 
   return (
-    <Card
-      shadow="sm"
-      padding="lg"
-      radius="md"
-      withBorder
-      style={{ backgroundColor: "#F5F7F8", maxWidth: "100%" }}
-    >
-      {!selectedFile && (
-        <Title
-          order={2}
-          mb="md"
-          style={{
-            fontSize: "24px",
-          }}
-        >
-          Inbox
-        </Title>
-      )}
-      {selectedFile ? (
-        <div>
-          <Title
-            order={3}
-            mb="md"
-            style={{
-              fontSize: "26px",
-            }}
-          >
-            File Subject
+    <>
+      {/* Embedded Responsive CSS */}
+      <style>{`
+        .inbox-card {
+          background-color: #f5f7f8;
+          max-width: 100%;
+          padding: 1rem;
+          overflow-x: hidden;
+        }
+        
+        .main-title {
+          font-size: 24px;
+        }
+        
+        .view-title {
+          font-size: 26px;
+          text-align: center;
+        }
+        
+        .files-container {
+          border: 1px solid #ddd;
+          border-radius: 8px;
+          overflow-y: auto;
+          height: 400px;
+          background-color: #fff;
+        }
+        
+        .table-scroll-wrapper {
+          min-width: 300px;
+        }
+        
+        .files-table {
+          width: 100%;
+          border-collapse: collapse;
+          table-layout: fixed;
+          font-size: 14px;
+          text-align: center;
+        }
+        
+        .files-table th {
+          padding: 12px;
+          border: 1px solid #ddd;
+          background-color: #f8f9fa;
+          text-align: center;
+          min-width: 100px;
+        }
+        
+        .files-table td {
+          padding: 12px;
+          border: 1px solid #ddd;
+          text-align: center;
+          vertical-align: middle;
+        }
+        
+        .archive-icon,
+        .view-icon {
+          margin: 0 auto;
+          transition: background-color 0.3s;
+          width: 2rem;
+          height: 2rem;
+        }
+        
+        /* Responsive Styles */
+        @media (max-width: 768px) {
+          .main-title {
+            font-size: 20px;
+          }
+          
+          .view-title {
+            font-size: 22px;
+          }
+          
+          .files-table {
+            display: block;
+            width: 100%;
+          }
+          
+          .files-table thead {
+            display: none;
+          }
+          
+          .files-table tbody,
+          .files-table tr,
+          .files-table td {
+            display: block;
+            width: 100%;
+          }
+          
+          .files-table tr {
+            margin-bottom: 1rem;
+            border: 2px solid #ddd;
+          }
+          
+          /* For textual data cells: align text to right with header labels */
+          .files-table td {
+            text-align: right;
+            padding-left: 50%;
+            position: relative;
+            border: none;
+            border-bottom: 1px solid #ddd;
+          }
+          
+          .files-table td::before {
+            content: attr(data-label);
+            position: absolute;
+            left: 0;
+            width: 45%;
+            padding-left: 1rem;
+            text-align: left;
+            font-weight: 600;
+          }
+          
+          /* For Archive and View File cells: do not display header labels and center the content */
+          .archive-cell::before,
+          .view-cell::before {
+            content: "";
+          }
+          .archive-cell,
+          .view-cell {
+            text-align: center !important;
+            padding-left: 0 !important;
+          }
+        }
+        
+        @media (max-width: 480px) {
+          .inbox-card {
+            padding: 0.5rem;
+          }
+          .files-table td {
+            padding: 8px;
+            padding-left: 50%;
+            font-size: 0.875rem;
+          }
+        }
+      `}</style>
+
+      <Card
+        shadow="sm"
+        padding="lg"
+        radius="md"
+        withBorder
+        className="inbox-card"
+      >
+        {!selectedFile && (
+          <Title order={2} mb="md" className="main-title">
+            Inbox
           </Title>
-          <View
-            onBack={handleBack}
-            fileID={selectedFile.id}
-            updateFiles={() =>
-              setFiles(files.filter((f) => f.id !== selectedFile.id))
-            }
-          />
-        </div>
-      ) : (
-        <Box
-          style={{
-            border: "1px solid #ddd",
-            borderRadius: "8px",
-            overflowY: "auto",
-            height: "400px",
-            backgroundColor: "#fff",
-          }}
-        >
-          <Table
-            highlightOnHover
-            style={{
-              width: "100%",
-              borderCollapse: "collapse",
-              tableLayout: "fixed",
-              fontSize: "14px",
-            }}
-          >
-            <thead>
-              <tr style={{ backgroundColor: "#0000" }}>
-                <th
-                  style={{
-                    padding: "12px",
-                    width: "8%",
-                    border: "1px solid #ddd",
-                  }}
-                >
-                  Archive
-                </th>
+        )}
 
-                <th style={{ padding: "12px", border: "1px solid #ddd" }}>
-                  Sent By
-                </th>
-                <th style={{ padding: "12px", border: "1px solid #ddd" }}>
-                  File ID
-                </th>
-                <th style={{ padding: "12px", border: "1px solid #ddd" }}>
-                  Subject
-                </th>
-                <th style={{ padding: "12px", border: "1px solid #ddd" }}>
-                  Date
-                </th>
-                <th
-                  style={{
-                    padding: "12px",
-                    width: "8.5%",
-                    border: "1px solid #ddd",
-                  }}
-                >
-                  View File
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {files.map((file, index) => (
-                <tr key={index}>
-                  <td
-                    style={{
-                      padding: "8px",
-                      textAlign: "center",
-                      border: "1px solid #ddd",
-                    }}
-                  >
-                    <Tooltip label="Archive file" position="top" withArrow>
-                      <ActionIcon
-                        variant="light"
-                        color="blue"
-                        style={{
-                          transition: "background-color 0.3s",
-                          width: "2rem",
-                          height: "2rem",
-                        }}
-                        data-default-color="transparent" // Store default color
-                        data-hover-color="#ffebee" // Store hover color
-                        onMouseEnter={handleMouseEnter} // Handle mouse enter
-                        onMouseLeave={handleMouseLeave} // Handle mouse leave
-                      >
-                        <Archive
-                          size="1rem"
-                          onClick={() => handleArchive(file.id)}
-                        />
-                      </ActionIcon>
-                    </Tooltip>
-                  </td>
-
-                  <td
-                    style={{
-                      padding: "12px",
-                      border: "1px solid #ddd",
-                      textAlign: "center",
-                    }}
-                  >
-                    {file.uploader}
-                  </td>
-                  <td
-                    style={{
-                      padding: "12px",
-                      border: "1px solid #ddd",
-                      textAlign: "center",
-                    }}
-                  >
-                    {file.id}
-                  </td>
-                  <td
-                    style={{
-                      padding: "12px",
-                      border: "1px solid #ddd",
-                      textAlign: "center",
-                    }}
-                  >
-                    {file.subject}
-                  </td>
-                  <td
-                    style={{
-                      padding: "12px",
-                      border: "1px solid #ddd",
-                      textAlign: "center",
-                    }}
-                  >
-                    {convertDate(file.upload_date)}
-                  </td>
-
-                  <td
-                    style={{
-                      padding: "12px",
-                      border: "1px solid #ddd",
-                      textAlign: "center",
-                      verticalAlign: "middle",
-                    }}
-                  >
-                    <ActionIcon
-                      variant="outline"
-                      color="black"
-                      style={{
-                        transition: "background-color 0.3s",
-                        width: "2rem",
-                        height: "2rem",
-                      }}
-                      data-default-color="white" // Store default color
-                      data-hover-color="#e0e0e0" // Store hover color
-                      onMouseEnter={handleMouseEnter} // Handle mouse enter
-                      onMouseLeave={handleMouseLeave} // Handle mouse leave
-                      onClick={() => setSelectedFile(file)}
-                    >
-                      <Eye size="1rem" />
-                    </ActionIcon>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </Table>
-        </Box>
-      )}
-    </Card>
+        {selectedFile ? (
+          <div>
+            <Title order={3} mb="md" className="view-title">
+              File Subject
+            </Title>
+            <View
+              onBack={handleBack}
+              fileID={selectedFile.id}
+              updateFiles={() =>
+                setFiles(files.filter((f) => f.id !== selectedFile.id))
+              }
+            />
+          </div>
+        ) : (
+          <Box className="files-container">
+            <div className="table-scroll-wrapper">
+              <Table className="files-table" highlightOnHover>
+                <thead>
+                  <tr>
+                    {/* In responsive view, leave header labels empty for Archive and View File */}
+                    <th data-label="">Archive</th>
+                    <th data-label="Sent By">Sent By</th>
+                    <th data-label="File ID">File ID</th>
+                    <th data-label="Subject">Subject</th>
+                    <th data-label="Date">Date</th>
+                    <th data-label="">View File</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {files.map((file, index) => (
+                    <tr key={index}>
+                      <td className="archive-cell" data-label="">
+                        <Tooltip label="Archive file" position="top" withArrow>
+                          <ActionIcon
+                            variant="light"
+                            color="blue"
+                            className="archive-icon"
+                            data-default-color="transparent"
+                            data-hover-color="#ffebee"
+                            onMouseEnter={handleMouseEnter}
+                            onMouseLeave={handleMouseLeave}
+                            onClick={() => handleArchive(file.id)}
+                          >
+                            <Archive size="1rem" />
+                          </ActionIcon>
+                        </Tooltip>
+                      </td>
+                      <td className="uploader-cell" data-label="Sent By">
+                        {file.uploader}
+                      </td>
+                      <td className="file-cell" data-label="File ID">
+                        {file.id}
+                      </td>
+                      <td className="subject-cell" data-label="Subject">
+                        {file.subject}
+                      </td>
+                      <td className="date-cell" data-label="Date">
+                        {convertDate(file.upload_date)}
+                      </td>
+                      <td className="view-cell" data-label="">
+                        <ActionIcon
+                          variant="outline"
+                          color="black"
+                          className="view-icon"
+                          data-default-color="white"
+                          data-hover-color="#e0e0e0"
+                          onMouseEnter={handleMouseEnter}
+                          onMouseLeave={handleMouseLeave}
+                          onClick={() => setSelectedFile(file)}
+                        >
+                          <Eye size="1rem" />
+                        </ActionIcon>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </Table>
+            </div>
+          </Box>
+        )}
+      </Card>
+    </>
   );
 }


### PR DESCRIPTION
I have handle archiving by attaching a click event to the archive icon that sends a POST request to archive the file and then immediately removes it from the list, ensuring users only see active files. For viewing responses, selecting a file sets it in state so that its detailed view component is rendered, allowing seamless tracking of file status and actions.

Before
![WhatsApp Image 2025-02-11 at 00 01 56_65ef8ce1](https://github.com/user-attachments/assets/58ee186b-9647-4351-9e66-30c9e51d5971)
After
![image](https://github.com/user-attachments/assets/aa0dff4e-db78-43f7-9a82-e9c6ad8642d9)
